### PR TITLE
[FIX] updated property configuration and fixed some test config setup

### DIFF
--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/platform/BootStrapperTestConfig.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/platform/BootStrapperTestConfig.java
@@ -1,11 +1,12 @@
 package org.molgenis.integrationtest.data.platform;
 
+import org.molgenis.data.TestPackage;
 import org.molgenis.data.platform.bootstrap.SystemEntityTypeBootstrapper;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({ SystemEntityTypeBootstrapper.class })
+@Import({ SystemEntityTypeBootstrapper.class, TestPackage.class })
 public class BootStrapperTestConfig
 {
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/settings/SettingsTestConfig.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/settings/SettingsTestConfig.java
@@ -4,13 +4,14 @@ import org.molgenis.data.settings.SettingsEntityType;
 import org.molgenis.data.settings.SettingsPackage;
 import org.molgenis.data.settings.SettingsPopulator;
 import org.molgenis.settings.PropertyType;
+import org.molgenis.ui.menumanager.MenuManagerServiceImpl;
 import org.molgenis.ui.settings.AppDbSettings;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import({ AppDbSettings.class, SettingsPackage.class, SettingsPopulator.class, SettingsEntityType.class,
-		PropertyType.class })
+		PropertyType.class, MenuManagerServiceImpl.class })
 public class SettingsTestConfig
 {
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/PlatformITConfig.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/PlatformITConfig.java
@@ -26,6 +26,7 @@ import org.molgenis.data.settings.AppSettings;
 import org.molgenis.data.transaction.TransactionManager;
 import org.molgenis.data.validation.ExpressionValidator;
 import org.molgenis.integrationtest.data.TestAppSettings;
+import org.molgenis.integrationtest.script.ScriptTestConfig;
 import org.molgenis.ontology.core.config.OntologyConfig;
 import org.molgenis.ontology.core.config.OntologyTestConfig;
 import org.molgenis.security.MolgenisRoleHierarchy;
@@ -86,14 +87,14 @@ import static org.molgenis.security.core.runas.SystemSecurityToken.ROLE_SYSTEM;
 		org.molgenis.data.RepositoryCollectionDecoratorFactoryImpl.class,
 		org.molgenis.data.RepositoryCollectionBootstrapper.class, org.molgenis.data.EntityFactoryRegistrar.class,
 		org.molgenis.data.importer.emx.EmxImportService.class, DataPersisterImpl.class,
-		org.molgenis.data.importer.ImportServiceFactory.class,
-		org.molgenis.data.FileRepositoryCollectionFactory.class, org.molgenis.data.excel.ExcelDataConfig.class,
+		org.molgenis.data.importer.ImportServiceFactory.class, org.molgenis.data.FileRepositoryCollectionFactory.class,
+		org.molgenis.data.excel.ExcelDataConfig.class,
 		org.molgenis.security.permission.PermissionSystemServiceImpl.class, PrincipalSecurityContextRegistryImpl.class,
 		AuthenticationAuthoritiesUpdaterImpl.class, SecurityContextRegistryImpl.class,
 		org.molgenis.data.importer.ImportServiceRegistrar.class, EntityTypeRegistryPopulator.class,
 		PermissionServiceImpl.class, MolgenisRoleHierarchy.class, SystemRepositoryDecoratorFactoryRegistrar.class,
 		SemanticSearchConfig.class, OntologyConfig.class, JobExecutionConfig.class, JobFactoryRegistrar.class,
-		SystemEntityTypeRegistryImpl.class, })
+		SystemEntityTypeRegistryImpl.class, ScriptTestConfig.class })
 public class PlatformITConfig implements ApplicationListener<ContextRefreshedEvent>
 {
 	private final static Logger LOG = LoggerFactory.getLogger(PlatformITConfig.class);

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/ui/ViewTestConfig.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/ui/ViewTestConfig.java
@@ -4,7 +4,6 @@ import org.molgenis.data.settings.AppSettings;
 import org.molgenis.ui.jobs.JobsController;
 import org.molgenis.ui.menu.MenuReaderService;
 import org.molgenis.ui.menu.MenuReaderServiceImpl;
-import org.molgenis.ui.menumanager.MenuManagerServiceImpl;
 import org.molgenis.ui.style.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Configuration
-@Import({ JobsController.class, MenuManagerServiceImpl.class, StyleSheetFactory.class, StyleSheetMetadata.class })
+@Import({ JobsController.class, StyleSheetFactory.class, StyleSheetMetadata.class })
 public class ViewTestConfig
 {
 	@Autowired

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/utils/AbstractMolgenisIntegrationTests.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/utils/AbstractMolgenisIntegrationTests.java
@@ -10,11 +10,14 @@ import org.molgenis.integrationtest.utils.config.WebAppITConfig;
 import org.molgenis.security.core.token.TokenService;
 import org.molgenis.util.ApplicationContextProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,7 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @WebAppConfiguration
-@TestPropertySource("/conf/molgenis.properties")
 @ContextConfiguration(classes = AbstractMolgenisIntegrationTests.Config.class)
 public abstract class AbstractMolgenisIntegrationTests extends AbstractTestNGSpringContextTests
 {
@@ -102,5 +104,17 @@ public abstract class AbstractMolgenisIntegrationTests extends AbstractTestNGSpr
 			PostgreSqlTestConfig.class, FileTestConfig.class, DatabaseConfig.class })
 	static class Config
 	{
+		@Bean
+		public static PropertySourcesPlaceholderConfigurer properties()
+		{
+			PropertySourcesPlaceholderConfigurer pspc = new PropertySourcesPlaceholderConfigurer();
+			Resource[] resources = new Resource[] { new ClassPathResource("/conf/molgenis.properties") };
+			pspc.setLocations(resources);
+			pspc.setFileEncoding("UTF-8");
+			pspc.setIgnoreUnresolvablePlaceholders(true);
+			pspc.setIgnoreResourceNotFound(true);
+			pspc.setNullValue("@null");
+			return pspc;
+		}
 	}
 }


### PR DESCRIPTION
We now think the PlatformIT database configuration is conflicting with the SortaControllerIT database configuration. 

In the PlatformIT we do not populate the AppDbSettings class, instead we are using the TestAppSettings class. This does not work for SortaControllerIT tests or in fact any other ControllerIT test because of the menuReaderService.getMenuUrl(). This has to be test-dependant because of the different menu-urls.

So you need to implement the real AppDbSettings in the SortaControllerIT which is not populated in the PlatformIT.

We have concluded that in every IT the database has to be cleaned in the IT teardown or afterclass.